### PR TITLE
fix: 🐛 UInt changed to Int for Java compatability

### DIFF
--- a/dotlottie/build.gradle.kts
+++ b/dotlottie/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.github.LottieFiles"
-version = "0.4.0"
+version = "0.4.1"
 
 android {
     namespace = "com.lottiefiles.dotlottie.core"

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/runtime/DotLottieController.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/runtime/DotLottieController.kt
@@ -138,7 +138,7 @@ class DotLottieController {
             }
 
             override fun onLoop(loopCount: UInt) {
-                eventListeners.forEach { it.onLoop(loopCount) }
+                eventListeners.forEach { it.onLoop(loopCount.toInt()) }
             }
 
             override fun onRender(frameNo: Float) {

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/drawable/DotLottieDrawable.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/drawable/DotLottieDrawable.kt
@@ -18,6 +18,7 @@ import com.dotlottie.dlplayer.Layout
 import com.dotlottie.dlplayer.Manifest
 import com.dotlottie.dlplayer.Marker
 import com.dotlottie.dlplayer.Mode
+import com.dotlottie.dlplayer.Observer
 import com.dotlottie.dlplayer.StateMachineObserver
 import com.lottiefiles.dotlottie.core.util.DotLottieContent
 import com.lottiefiles.dotlottie.core.util.StateMachineEventListener
@@ -149,6 +150,47 @@ class DotLottieDrawable(
         }
     }
 
+    private fun subscribe() {
+        val observer = object : Observer {
+            override fun onComplete() {
+                dotLottieEventListener.forEach(DotLottieEventListener::onComplete)
+            }
+
+            override fun onFrame(frameNo: Float) {
+                dotLottieEventListener.forEach { it.onFrame(frameNo) }
+            }
+
+            override fun onPause() {
+                dotLottieEventListener.forEach(DotLottieEventListener::onPause)
+            }
+
+            override fun onStop() {
+                dotLottieEventListener.forEach(DotLottieEventListener::onStop)
+            }
+
+            override fun onPlay() {
+                dotLottieEventListener.forEach(DotLottieEventListener::onPlay)
+            }
+
+            override fun onLoad() {
+                dotLottieEventListener.forEach(DotLottieEventListener::onLoad)
+            }
+
+            override fun onLoop(loopCount: UInt) {
+                dotLottieEventListener.forEach { it.onLoop(loopCount.toInt()) }
+            }
+
+            override fun onRender(frameNo: Float) {
+                dotLottieEventListener.forEach { it.onRender(frameNo) }
+            }
+
+            override fun onLoadError() {
+                dotLottieEventListener.forEach(DotLottieEventListener::onLoadError)
+            }
+        }
+        dlPlayer?.subscribe(observer)
+    }
+
     private fun initialize() {
         dlPlayer = DotLottiePlayer(config)
         when (animationData) {
@@ -166,9 +208,7 @@ class DotLottieDrawable(
         }
         bitmapBuffer = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         nativeBuffer = Pointer(dlPlayer!!.bufferPtr().toLong())
-        dotLottieEventListener.forEach {
-            dlPlayer!!.subscribe(it)
-        }
+        this.subscribe()
     }
 
     fun release() {

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieEventListener.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieEventListener.kt
@@ -14,5 +14,4 @@ interface DotLottieEventListener {
     fun onFreeze() {}
     fun onUnFreeze() {}
     fun onDestroy() {}
-    fun onError(error: Throwable) {}
 }

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieEventListener.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieEventListener.kt
@@ -1,20 +1,18 @@
 package com.lottiefiles.dotlottie.core.util
 
-import com.dotlottie.dlplayer.Observer
-
-interface DotLottieEventListener : Observer {
-    override fun onLoop(loopCount: UInt) {}
-    override fun onRender(frameNo: Float) {}
-    override fun onStop() {}
-    override fun onFrame(frame: Float) {}
-    override fun onPause() {}
-    override fun onPlay() { }
-    override fun onComplete() { }
-    override fun onLoad() { }
-    override fun onLoadError() { }
+interface DotLottieEventListener {
+    fun onLoop(loopCount: Int) {}
+    fun onRender(frameNo: Float) {}
+    fun onStop() {}
+    fun onFrame(frame: Float) {}
+    fun onPause() {}
+    fun onPlay() {}
+    fun onComplete() {}
+    fun onLoad() {}
+    fun onLoadError() {}
     fun onLoadError(error: Throwable) {}
     fun onFreeze() {}
     fun onUnFreeze() {}
     fun onDestroy() {}
-    fun onLoop() {}
+    fun onError(error: Throwable) {}
 }

--- a/sample/src/main/java/com/lottiefiles/sample/MainActivity.kt
+++ b/sample/src/main/java/com/lottiefiles/sample/MainActivity.kt
@@ -51,8 +51,8 @@ class MainActivity : ComponentActivity() {
 //            )
         }
 
-        override fun onLoop() {
-            Log.d(TAG, "On Loop")
+        override fun onLoop(loopCount: Int) {
+            Log.d(TAG, "On Loop -> $loopCount")
         }
 
         override fun onComplete() {


### PR DESCRIPTION
- The DotLottieEventListener interface method signature has been updated from fun onLoop(loopCount: UInt) {} to fun onLoop(loopCount: Int) {} for improved Java compatibility.

Error: 
```
Class 'Anonymous class derived from DotLottieEventListener' must implement abstract method 'onLoop-WZ4Q5Ns(int)' in 'DotLottieEventListener'
```

Issue:
Kotlin’s UInt type is not directly supported in Java, leading to issues when interacting with the onLoop function from Java. The Kotlin compiler generates a method with a mangled name like onLoop-WZ4Q5Ns(int) to handle the UInt.

Solution:
By changing the parameter type from UInt to Int, we ensure that the method is fully compatible with Java, avoiding the name mangling issue and simplifying usage in mixed Kotlin/Java projects.