### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ repositories {
 
 ```kotlin
 dependencies {
-    implementation("com.github.LottieFiles:dotlottie-android:0.3.0")
+    implementation("com.github.LottieFiles:dotlottie-android:0.5.0")
 }
 
 ```
@@ -64,7 +64,9 @@ Set up the initial animation configuration
 
 #### Traditional UI 
 ```kotlin
-val config = DotLottieConfig.Builder()
+import com.lottiefiles.dotlottie.core.model.Config
+
+val config = Config.Builder()
     .autoplay(true)
     .speed(1f)
     .loop(true)


### PR DESCRIPTION
Hello. Recently I integrated this library in a project of mine and noticed the `DotLottieConfig` did not exist, only the `Config` class, so I suppose it was renamed and not integrated in the README, so this fixes it if welcome. 