### PR TITLE
fix: better check for network source to determine file type

### DIFF
--- a/dotlottie/build.gradle.kts
+++ b/dotlottie/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.github.LottieFiles"
-version = "0.6.2"
+version = "0.6.3"
 
 android {
     namespace = "com.lottiefiles.dotlottie.core"

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/loader/NetworkLoader.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/loader/NetworkLoader.kt
@@ -2,6 +2,7 @@ package com.lottiefiles.dotlottie.core.loader
 
 import android.content.Context
 import com.lottiefiles.dotlottie.core.util.DotLottieContent
+import com.lottiefiles.dotlottie.core.util.isZipCompressed
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
@@ -74,10 +75,11 @@ class NetworkLoader(context: Context, private val url: String) : AbstractLoader(
                 throw IOException("[NetworkLoader]: Failed to download file: $url")
             }
 
-            val contentType = response.header("Content-Type", "") ?: "";
-            val isLottie =
-                contentType.contains("application/json") || contentType.contains("text/plain")
-            val content = if (isLottie) {
+            val isDotLottie = response.body?.source()
+                ?.isZipCompressed()
+                ?:false
+
+            val content = if (!isDotLottie) {
                 val text = response.body?.string()
                     ?: throw IOException("Response body is null: $url")
                 cacheJson(text)

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieUtils.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieUtils.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import androidx.lifecycle.LifecycleOwner
 import com.lottiefiles.dotlottie.core.loader.DotLottieResult
+import okio.BufferedSource
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
@@ -25,6 +26,12 @@ fun String.isUrl(): Boolean {
     return startsWith("http") || startsWith("https")
 }
 
+val ZIP_MAGIC: ByteArray = byteArrayOf(0x50, 0x4b, 0x03, 0x04)
+
+fun BufferedSource.isZipCompressed(): Boolean {
+    return matchesMagicBytes(this, ZIP_MAGIC)
+}
+
 fun Context.lifecycleOwner(): LifecycleOwner? {
     var curContext = this
     var maxDepth = 20
@@ -38,50 +45,70 @@ fun Context.lifecycleOwner(): LifecycleOwner? {
     }
 }
 
+fun matchesMagicBytes(inputSource: BufferedSource, magic: ByteArray): Boolean {
+    try {
+        val peek = inputSource.peek()
+        for (b in magic) {
+            if (peek.readByte() != b) {
+                return false
+            }
+        }
+        peek.close()
+        return true
+    } catch (e: NoSuchMethodError) {
+        // This happens in the Android Studio layout preview.
+        return false
+    } catch (e: java.lang.Exception) {
+        return false
+    }
+}
 
 
 object DotLottieUtils {
     suspend fun getContent(context: Context, source: DotLottieSource): DotLottieContent {
-            when (source) {
-                is DotLottieSource.Url -> {
-                    return suspendCoroutine {cont ->
-                        DotLottieLoader.with(context).fromUrl(source.urlString).load(object :
-                            DotLottieResult {
-                            override fun onSuccess(result: DotLottieContent) {
-                                cont.resume(result)
-                            }
+        when (source) {
+            is DotLottieSource.Url -> {
+                return suspendCoroutine { cont ->
+                    DotLottieLoader.with(context).fromUrl(source.urlString).load(object :
+                        DotLottieResult {
+                        override fun onSuccess(result: DotLottieContent) {
+                            cont.resume(result)
+                        }
 
-                            override fun onError(throwable: Throwable) {
-                                cont.resumeWithException(throwable)
-                            }
-                        })
-                    }
-                }
-                is DotLottieSource.Asset -> {
-                    return suspendCoroutine {cont ->
-                        DotLottieLoader.with(context).fromAsset(source.assetPath).load(object :
-                            DotLottieResult {
-                            override fun onSuccess(result: DotLottieContent) {
-                                cont.resume(result)
-                            }
-
-                            override fun onError(throwable: Throwable) {
-                                cont.resumeWithException(throwable)
-                            }
-                        })
-                    }
-                }
-                is DotLottieSource.Json -> {
-                    return suspendCoroutine {cont ->
-                        cont.resume(DotLottieContent.Json(source.jsonString))
-                    }
-                }
-                is DotLottieSource.Data -> {
-                    return suspendCoroutine {cont ->
-                        cont.resume(DotLottieContent.Binary(source.data))
-                    }
+                        override fun onError(throwable: Throwable) {
+                            cont.resumeWithException(throwable)
+                        }
+                    })
                 }
             }
+
+            is DotLottieSource.Asset -> {
+                return suspendCoroutine { cont ->
+                    DotLottieLoader.with(context).fromAsset(source.assetPath).load(object :
+                        DotLottieResult {
+                        override fun onSuccess(result: DotLottieContent) {
+                            cont.resume(result)
+                        }
+
+                        override fun onError(throwable: Throwable) {
+                            cont.resumeWithException(throwable)
+                        }
+                    })
+                }
+            }
+
+            is DotLottieSource.Json -> {
+                return suspendCoroutine { cont ->
+                    cont.resume(DotLottieContent.Json(source.jsonString))
+                }
+            }
+
+            is DotLottieSource.Data -> {
+                return suspendCoroutine { cont ->
+                    cont.resume(DotLottieContent.Binary(source.data))
+                }
+            }
+        }
     }
 
     private fun byteArrayToFile(context: Context, data: ByteArray): File? {


### PR DESCRIPTION
This fix changes the mechanism used to determine if a network file is a dotLottie or JSON.

Previously the SDK relied on mime-type for this. However, we noticed several instances of this failing and incorrectly trying tying to parse .lottie as .json.

Here we introduce checking the magic bytes on the response file instead of mime-type as a more reliable way to determine the file type.