### PR TITLE
fix: 🐛 crash when loading DotLottieDrawable a second time

### DIFF
--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,2 @@
+build
+.gradle

--- a/dotlottie/build.gradle.kts
+++ b/dotlottie/build.gradle.kts
@@ -37,7 +37,7 @@ dotlottieRust {
 }
 
 group = "com.github.LottieFiles"
-version = "0.13.5"
+version = "0.13.6"
 
 android {
     namespace = "com.lottiefiles.dotlottie.core"

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/drawable/DotLottieDrawable.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/drawable/DotLottieDrawable.kt
@@ -39,8 +39,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-private val drawableCleanupScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
 class DotLottieDrawable(
     private val animationData: DotLottieContent,
     private var width: Int = 0,
@@ -305,24 +303,17 @@ class DotLottieDrawable(
     fun release() {
         choreographer.removeFrameCallback(frameCallback)
         renderScope.cancel()
-        // Capture references for background cleanup, then null out instance fields
         val capturedPlayer = dlPlayer
         val capturedBitmap = bitmapBuffer
-        val capturedMutex = renderMutex
         dlPlayer = null
         bitmapBuffer = null
-        // Fire listeners synchronously before async cleanup
         dotLottieEventListener.forEach(DotLottieEventListener::onDestroy)
-        // Free native resources on a background thread to avoid blocking the main thread
+
         if (capturedPlayer != null) {
-            drawableCleanupScope.launch {
-                capturedMutex.withLock {
-                    capturedBitmap?.let { DotLottieJNI.nativeUnlockBitmapPixels(it) }
-                    capturedPlayer.destroy()
-                }
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                    capturedBitmap?.recycle()
-                }
+            capturedBitmap?.let { DotLottieJNI.nativeUnlockBitmapPixels(it) }
+            capturedPlayer.destroy()
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                capturedBitmap?.recycle()
             }
         }
     }


### PR DESCRIPTION
# SIGSEGV crash when loading DotLottieDrawable a second time

## Summary

The app crashes with `SIGSEGV` when a `DotLottieDrawable` is disposed and a new one is created —
e.g. navigating away from a page containing `DotLottieDrawable` and then navigating back.

## Fix
DotLottieDrawable.release() now destroys synchronously on the caller's thread instead of launching
  capturedPlayer.destroy() on drawableCleanupScope (IO). This removes the race where the last player's drop could
  concurrently call tvg_engine_term() while the next player's init/tick ran on main. Matches the Compose component cleanup behavior
  
  
  Solves: https://github.com/LottieFiles/dotlottie-flutter/issues/8
  https://github.com/LottieFiles/dotlottie-android/issues/111