### PR TITLE
Move native animation load off the main thread

### DIFF
--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieAnimation.kt
@@ -2,6 +2,8 @@ package com.lottiefiles.dotlottie.core.compose.ui
 
 import android.graphics.Bitmap
 import android.os.Build
+import android.os.SystemClock
+import android.util.Log
 import android.view.Choreographer
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.defaultMinSize
@@ -46,6 +48,16 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+
+private const val TAG = "DotLottieAnimation"
+
+// Log a warning when a single tick blows past two vsync intervals at 60Hz —
+// helps attribute future ANRs to long native tick calls.
+private const val SLOW_TICK_THRESHOLD_MS = 32L
+
+// Log a warning when the native parse/decode takes longer than this —
+// helps attribute future ANRs to long native load calls.
+private const val SLOW_LOAD_THRESHOLD_MS = 100L
 
 private val cleanupScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -116,10 +128,15 @@ fun DotLottieAnimation(
                     return
                 }
 
+                val tickStartMs = SystemClock.uptimeMillis()
                 val ticked = if (rController.stateMachineIsActive) {
                     dlPlayer.stateMachineTick()
                 } else {
                     dlPlayer.tick()
+                }
+                val tickElapsedMs = SystemClock.uptimeMillis() - tickStartMs
+                if (tickElapsedMs > SLOW_TICK_THRESHOLD_MS) {
+                    Log.w(TAG, "tick took ${tickElapsedMs}ms (stateMachine=${rController.stateMachineIsActive})")
                 }
 
                 // Poll and dispatch events
@@ -188,13 +205,23 @@ fun DotLottieAnimation(
                 if (pixelPtr == 0L) return@withLock
                 dlPlayer.setSwTarget(pixelPtr, width, height)
 
-                when (animationData) {
-                    is DotLottieContent.Json -> {
-                        dlPlayer.loadAnimationData(animationData.jsonString, width, height)
-                    }
+                // Native parse/decode can be slow for large .lottie archives — run off the
+                // main thread to avoid ANRs. The render loop on Main already skips frames
+                // via renderMutex.tryLock() while this is in flight.
+                withContext(Dispatchers.Default) {
+                    val startMs = SystemClock.uptimeMillis()
+                    when (animationData) {
+                        is DotLottieContent.Json -> {
+                            dlPlayer.loadAnimationData(animationData.jsonString, width, height)
+                        }
 
-                    is DotLottieContent.Binary -> {
-                        dlPlayer.loadDotlottieData(animationData.data, width, height)
+                        is DotLottieContent.Binary -> {
+                            dlPlayer.loadDotlottieData(animationData.data, width, height)
+                        }
+                    }
+                    val elapsedMs = SystemClock.uptimeMillis() - startMs
+                    if (elapsedMs > SLOW_LOAD_THRESHOLD_MS) {
+                        Log.w(TAG, "load took ${elapsedMs}ms (size=${width}x${height})")
                     }
                 }
 

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/drawable/DotLottieDrawable.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/drawable/DotLottieDrawable.kt
@@ -9,6 +9,8 @@ import android.graphics.PointF
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.os.Build
+import android.os.SystemClock
+import android.util.Log
 import android.view.Choreographer
 import androidx.annotation.ColorInt
 import androidx.annotation.FloatRange
@@ -106,10 +108,15 @@ class DotLottieDrawable(
             }
 
             // stateMachineTick() calls player tick() internally (player is borrowed by state machine)
+            val tickStartMs = SystemClock.uptimeMillis()
             val ticked = if (stateMachineIsActive) {
                 player.stateMachineTick()
             } else {
                 player.tick()
+            }
+            val tickElapsedMs = SystemClock.uptimeMillis() - tickStartMs
+            if (tickElapsedMs > SLOW_TICK_THRESHOLD_MS) {
+                Log.w(TAG, "tick took ${tickElapsedMs}ms (stateMachine=$stateMachineIsActive)")
             }
 
             // Poll and dispatch events on main thread
@@ -239,65 +246,100 @@ class DotLottieDrawable(
         get() = dlPlayer?.isLoaded() ?: false
 
 
-    private var initialized = false
+    @Volatile private var initialized = false
+    @Volatile private var initializing = false
 
     /**
-     * Initialize the native player and load the animation.
-     * MUST be called on the main thread (ThorVG has thread affinity for rendering).
+     * Trigger native player creation and animation load off the main thread.
+     * The first call from [draw] launches the work on [renderScope]; subsequent
+     * calls are no-ops until init completes (or fails). Once initialized, a
+     * frame is scheduled on the main thread to render the loaded animation.
      */
     private fun ensureInitialized() {
-        if (initialized) return
+        if (initialized || initializing) return
         if (width <= 0 || height <= 0) return
 
-        try {
-            dlPlayer = if (threads != null) {
-                DotLottiePlayer.withThreads(config, threads)
-            } else {
-                DotLottiePlayer(config)
+        initializing = true
+        renderScope.launch {
+            val player = try {
+                if (threads != null) {
+                    DotLottiePlayer.withThreads(config, threads)
+                } else {
+                    DotLottiePlayer(config)
+                }
+            } catch (e: Throwable) {
+                withContext(Dispatchers.Main) {
+                    initializing = false
+                    dotLottieEventListener.forEach { it.onLoadError(e) }
+                }
+                return@launch
             }
-            setupBufferAndLoad()
 
-            // Load and start state machine if configured
-            if (config.stateMachineId.isNotEmpty()) {
-                stateMachineLoad(config.stateMachineId)
-                stateMachineStart()
+            var lockedBitmap: Bitmap? = null
+            var assigned = false
+            try {
+                renderMutex.withLock {
+                    val bmp = createBitmap(width, height)
+                    val pixelPtr = DotLottieJNI.nativeLockBitmapPixels(bmp)
+                    if (pixelPtr == 0L) return@withLock
+                    lockedBitmap = bmp
+                    player.setSwTarget(pixelPtr, width.toUInt(), height.toUInt())
+
+                    val startMs = SystemClock.uptimeMillis()
+                    when (animationData) {
+                        is DotLottieContent.Json -> player.loadAnimationData(
+                            animationData.jsonString,
+                            width.toUInt(),
+                            height.toUInt()
+                        )
+
+                        is DotLottieContent.Binary -> player.loadDotlottieData(
+                            animationData.data,
+                            width.toUInt(),
+                            height.toUInt()
+                        )
+                    }
+                    val elapsedMs = SystemClock.uptimeMillis() - startMs
+                    if (elapsedMs > SLOW_LOAD_THRESHOLD_MS) {
+                        Log.w(TAG, "load took ${elapsedMs}ms (size=${width}x${height})")
+                    }
+
+                    dlPlayer = player
+                    bitmapBuffer = bmp
+                    assigned = true
+                }
+
+                if (!assigned) {
+                    lockedBitmap?.let { DotLottieJNI.nativeUnlockBitmapPixels(it) }
+                    player.destroy()
+                    withContext(Dispatchers.Main) {
+                        initializing = false
+                    }
+                    return@launch
+                }
+
+                withContext(Dispatchers.Main) {
+                    // State machine wiring mutates state read from the Choreographer callback
+                    // on Main — keep those writes on Main to avoid cross-thread races.
+                    if (config.stateMachineId.isNotEmpty()) {
+                        stateMachineLoad(config.stateMachineId)
+                        stateMachineStart()
+                    }
+                    initialized = true
+                    initializing = false
+                    scheduleFrame(forceUpdate = true)
+                }
+            } catch (e: Throwable) {
+                if (!assigned) {
+                    lockedBitmap?.let { DotLottieJNI.nativeUnlockBitmapPixels(it) }
+                    player.destroy()
+                }
+                withContext(Dispatchers.Main) {
+                    initializing = false
+                    dotLottieEventListener.forEach { it.onLoadError(e) }
+                }
             }
-
-            initialized = true
-            scheduleFrame(forceUpdate = true)
-        } catch (e: Throwable) {
-            // Clean up partially initialized state so retry is possible
-            dlPlayer?.destroy()
-            dlPlayer = null
-            dotLottieEventListener.forEach { it.onLoadError(e) }
         }
-    }
-
-    private fun setupBufferAndLoad() {
-        val player = dlPlayer ?: return
-
-        // 1. Create bitmap and lock its pixels as the render target (zero-copy)
-        val newBitmap = createBitmap(width, height)
-        val pixelPtr = DotLottieJNI.nativeLockBitmapPixels(newBitmap)
-        if (pixelPtr == 0L) return
-        player.setSwTarget(pixelPtr, width.toUInt(), height.toUInt())
-
-        // 2. Load animation
-        when (animationData) {
-            is DotLottieContent.Json -> {
-                player.loadAnimationData(
-                    animationData.jsonString,
-                    width.toUInt(),
-                    height.toUInt()
-                )
-            }
-
-            is DotLottieContent.Binary -> {
-                player.loadDotlottieData(animationData.data, width.toUInt(), height.toUInt())
-            }
-        }
-
-        bitmapBuffer = newBitmap
     }
 
     fun release() {
@@ -601,7 +643,7 @@ class DotLottieDrawable(
     }
 
     override fun draw(canvas: Canvas) {
-        // Lazy init on main thread (ThorVG requires thread affinity)
+        // First draw triggers async load; subsequent draws no-op until init completes
         ensureInitialized()
 
         bitmapBuffer?.let { bmp ->
@@ -614,6 +656,14 @@ class DotLottieDrawable(
     companion object {
 
         private const val TAG = "DotLottieDrawable"
+
+        // Log a warning when a single tick blows past two vsync intervals at 60Hz —
+        // helps attribute future ANRs to long native tick calls.
+        private const val SLOW_TICK_THRESHOLD_MS = 32L
+
+        // Log a warning when the native parse/decode takes longer than this —
+        // helps attribute future ANRs to long native load calls.
+        private const val SLOW_LOAD_THRESHOLD_MS = 100L
 
         private const val LOTTIE_INFO_FRAME_COUNT = 0
         private const val LOTTIE_INFO_DURATION = 1


### PR DESCRIPTION
## Problem
A cluster of ANRs has been reported where the main thread is blocked inside the native dotLottie player — most commonly in `dotlottie_load_dotlottie_data`, occasionally in `dotlottie_tick`, with `LottieTrace.beginSection` on the same stack. Parsing a `.lottie` archive and decoding its embedded assets runs synchronously, and for large files that decode can blow past the ANR window on slower devices.

## Solution
Move the native parse/decode calls (`loadAnimationData` / `loadDotlottieData`) off the main thread. The Compose path wraps the FFI call in `withContext(Dispatchers.Default)` inside the existing `renderMutex.withLock { … }` block. The View drawable's `ensureInitialized()` — which was being triggered synchronously from `draw()` on Main — now launches on `renderScope` (already `Dispatchers.Default`) and returns early from `draw()` until init completes. Serialization with the tick loop is preserved because the render mutex is held for the whole load, and the Choreographer callback already uses `tryLock()` to skip frames non-blockingly.

Also added warning logs around load and tick with named thresholds (`SLOW_LOAD_THRESHOLD_MS`, `SLOW_TICK_THRESHOLD_MS`) so future ANRs on these paths can be attributed from logcat.

## Test
- Load a large `.lottie` asset in `sample-compose` and `sample` and confirm the UI thread is responsive during the initial load
- Confirm the first frame still appears once the load completes (View path returns early from `draw()` until init completes, then `invalidateSelf()` triggers a redraw via `scheduleFrame`)
- Run the multi-instance stress test in `sample-compose` and confirm no regressions in playback or disposal
- Rotate the device during an in-flight load and confirm the drawable is torn down cleanly (`release()` cancels `renderScope` and destroys the player)