### PR TITLE
(android): implement persistent CPU performance mode and lifecycle stability guards

### DIFF
--- a/.changeset/cpu-performance-mode.md
+++ b/.changeset/cpu-performance-mode.md
@@ -1,0 +1,5 @@
+---
+"dotlottie-android": minor
+---
+
+Add `performanceMode` and `cacheId` to `DotLottieGLSurfaceAnimation` and `DotLottieGLAnimation` to support keeping the player alive across surface recreation (CPU mode). Add `onSurfaceReady` callback to `DotLottieEventListener` and implement player caching and frame restoration. Fix safe GL context destruction and player lifecycle management in CPU mode.

--- a/dotlottie/build.gradle.kts
+++ b/dotlottie/build.gradle.kts
@@ -37,7 +37,7 @@ dotlottieRust {
 }
 
 group = "com.github.LottieFiles"
-version = "0.13.7"
+version = "9.9.9-LOCAL"
 
 android {
     namespace = "com.lottiefiles.dotlottie.core"

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieGLAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieGLAnimation.kt
@@ -39,6 +39,9 @@ fun DotLottieGLAnimation(
     eventListeners: List<DotLottieEventListener> = emptyList(),
     threads: UInt? = null,
     loopCount: UInt = 0u,
+    performanceMode: Int = 0,
+
+    cacheId: String = "",
 ) {
     // TODO: Add HardwareBuffer support for API 31+
     DotLottieGLSurfaceAnimation(
@@ -58,5 +61,7 @@ fun DotLottieGLAnimation(
         eventListeners = eventListeners,
         threads = threads,
         loopCount = loopCount,
+        performanceMode = performanceMode,
+        cacheId = cacheId,
     )
 }

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieGLSurfaceAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieGLSurfaceAnimation.kt
@@ -104,7 +104,9 @@ internal fun DotLottieGLSurfaceAnimation(
 
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
-            glWidgetRef[0]?.destroy()
+            val widget = glWidgetRef[0]
+            widget?.onPause() // Stop render loop immediately
+            widget?.destroy()
             glWidgetRef[0] = null
         }
     }

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieGLSurfaceAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/compose/ui/DotLottieGLSurfaceAnimation.kt
@@ -41,6 +41,9 @@ internal fun DotLottieGLSurfaceAnimation(
     eventListeners: List<DotLottieEventListener> = emptyList(),
     @Suppress("UNUSED_PARAMETER") threads: UInt? = null,
     loopCount: UInt = 0u,
+    performanceMode: Int = 0,
+
+    cacheId: String = "",
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -111,6 +114,9 @@ internal fun DotLottieGLSurfaceAnimation(
         factory = { ctx ->
             GLWidget(ctx).also { widget ->
                 glWidgetRef[0] = widget
+
+                widget.setPerformanceMode(performanceMode)
+                widget.setCacheId(cacheId)
 
                 // Add event listeners
                 eventListeners.forEach { widget.addEventListener(it) }

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieEventListener.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/util/DotLottieEventListener.kt
@@ -15,4 +15,5 @@ interface DotLottieEventListener {
     fun onUnFreeze() {}
     fun onDestroy() {}
     fun onError(error: Throwable) {}
+    fun onSurfaceReady() {}
 }

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/widget/DotLottieGLAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/widget/DotLottieGLAnimation.kt
@@ -857,6 +857,7 @@ class DotLottieGLAnimation @JvmOverloads constructor(
     }
 
     fun destroy() {
+        if (performanceMode == 1) return // Keep alive in CPU mode
         sharedGl.handler.post { destroyPlayerOnGlThread() }
     }
 
@@ -1068,13 +1069,16 @@ class DotLottieGLAnimation @JvmOverloads constructor(
     // ==================== View Lifecycle ====================
 
     override fun onDetachedFromWindow() {
+        paused = true // STOP IMMEDIATELY
         super.onDetachedFromWindow()
         loadJob?.cancel()
         coroutineScope.cancel()
         surfaceReady = false
         sharedGl.handler.post {
             sharedGl.unregisterOnGlThread(this)
-            destroyPlayerOnGlThread()
+            if (performanceMode != 1) {
+                destroyPlayerOnGlThread()
+            }
             destroyRenderFbo()
             if (eglSurface != EGL14.EGL_NO_SURFACE) {
                 sharedGl.destroyWindowSurface(eglSurface)

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/widget/DotLottieGLAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/widget/DotLottieGLAnimation.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlin.jvm.JvmStatic
 
 @ExperimentalDotLottieGLApi
 class DotLottieGLAnimation @JvmOverloads constructor(
@@ -282,29 +283,30 @@ class DotLottieGLAnimation @JvmOverloads constructor(
                 }
                 initPlayerOnGlThread()
 
-            val player = dlPlayer ?: return@post
-            sharedGl.makeCurrent(eglSurface)
+                val player = dlPlayer ?: return@post
+                sharedGl.makeCurrent(eglSurface)
 
-            // Create intermediate render FBO
-            destroyRenderFbo()
-            createRenderFbo()
-            if (renderFboId == 0) return@post
+                // Create intermediate render FBO
+                destroyRenderFbo()
+                createRenderFbo()
+                if (renderFboId == 0) return@post
 
-            player.setGlTarget(
-                sharedGl.eglDisplay.nativeHandle,
-                eglSurface.nativeHandle,
-                sharedGl.eglContext.nativeHandle,
-                renderFboId,
-                width.toUInt(),
-                height.toUInt()
-            )
-            glTargetDirty = false
+                player.setGlTarget(
+                    sharedGl.eglDisplay.nativeHandle,
+                    eglSurface.nativeHandle,
+                    sharedGl.eglContext.nativeHandle,
+                    renderFboId,
+                    width.toUInt(),
+                    height.toUInt()
+                )
+                glTargetDirty = false
 
-            // Load pending content or reload last content
-            val content = pendingContent ?: lastLoadedContent
-            if (content != null) {
-                pendingContent = null
-                loadContentOnGlThread(content)
+                // Load pending content or reload last content
+                val content = pendingContent ?: lastLoadedContent
+                if (content != null) {
+                    pendingContent = null
+                    loadContentOnGlThread(content)
+                }
             }
         }
         sharedGl.register(this)
@@ -1112,5 +1114,15 @@ class DotLottieGLAnimation @JvmOverloads constructor(
         val playerCache = mutableMapOf<String, DotLottiePlayer>()
         // Saved frames for RAM mode keyed by cacheId
         val savedFrames = mutableMapOf<String, Float>()
+
+        /**
+         * Release a cached player instance to prevent memory leaks.
+         * Should be called when the animation is no longer needed across screens.
+         */
+        @JvmStatic
+        fun releaseCache(cacheId: String) {
+            playerCache.remove(cacheId)?.destroy()
+            savedFrames.remove(cacheId)
+        }
     }
 }

--- a/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/widget/DotLottieGLAnimation.kt
+++ b/dotlottie/src/main/java/com/lottiefiles/dotlottie/core/widget/DotLottieGLAnimation.kt
@@ -55,6 +55,9 @@ class DotLottieGLAnimation @JvmOverloads constructor(
 
     private val sharedGl = SharedGlThread.instance
 
+    private var performanceMode: Int = 0
+    private var cacheId: String = ""
+
     private var dlPlayer: DotLottiePlayer? = null
     private var dlConfig: Config? = null
     private var eglSurface: EGLSurface = EGL14.EGL_NO_SURFACE
@@ -236,11 +239,48 @@ class DotLottieGLAnimation @JvmOverloads constructor(
             surfaceReady = true
             glTargetDirty = true
 
-            // (Re)create player
-            if (initialized) {
-                destroyPlayerOnGlThread()
-            }
-            initPlayerOnGlThread()
+            // CPU mode: player kept alive across surface destroy/create
+            if (performanceMode == 1 && dlPlayer != null) {
+                val player = dlPlayer ?: return@post
+                sharedGl.makeCurrent(eglSurface)
+
+                destroyRenderFbo()
+                createRenderFbo()
+                if (renderFboId == 0) return@post
+
+                // Rebind GL target to new surface on existing player
+                player.setGlTarget(
+                        sharedGl.eglDisplay.nativeHandle,
+                        eglSurface.nativeHandle,
+                        sharedGl.eglContext.nativeHandle,
+                        renderFboId,
+                        width.toUInt(),
+                        height.toUInt()
+                )
+                glTargetDirty = false
+                player.resize(width.toUInt(), height.toUInt())
+
+                // Restore saved frame
+                if (cacheId.isNotEmpty() && savedFrames.containsKey(cacheId)) {
+                    val savedFrame = savedFrames[cacheId]
+                    if (savedFrame != null) {
+                        player.setFrame(savedFrame)
+                        savedFrames.remove(cacheId)
+                    }
+                }
+
+                // Render immediately
+                dirtyFrame = true
+                sharedGl.requestRender()
+
+                // Notify surface ready
+                post { eventListeners.forEach { it.onSurfaceReady() } }
+            } else {
+                // Default / RAM mode: destroy and recreate player
+                if (initialized) {
+                    destroyPlayerOnGlThread()
+                }
+                initPlayerOnGlThread()
 
             val player = dlPlayer ?: return@post
             sharedGl.makeCurrent(eglSurface)
@@ -305,8 +345,19 @@ class DotLottieGLAnimation @JvmOverloads constructor(
         surfaceReady = false
         sharedGl.handler.post {
             sharedGl.unregisterOnGlThread(this)
-            destroyPlayerOnGlThread()
+
+            // Save current frame for all modes if cacheId is set
+            if (cacheId.isNotEmpty()) {
+                dlPlayer?.let { player -> savedFrames[cacheId] = player.currentFrame() }
+            }
+
+            // CPU mode: keep player alive, only destroy GL resources
+            if (performanceMode != 1 || cacheId.isEmpty()) {
+                destroyPlayerOnGlThread()
+            }
+
             destroyRenderFbo()
+
             if (eglSurface != EGL14.EGL_NO_SURFACE) {
                 sharedGl.destroyWindowSurface(eglSurface)
                 eglSurface = EGL14.EGL_NO_SURFACE
@@ -397,11 +448,29 @@ class DotLottieGLAnimation @JvmOverloads constructor(
             loopCount = attrLoopCount
         )
 
-        dlPlayer = if (attrThreads != null) {
-            DotLottiePlayer.withThreads(config, attrThreads!!)
+        if (performanceMode == 1 && cacheId.isNotEmpty()) {
+
+            val cachedPlayer = playerCache[cacheId]
+            if (cachedPlayer != null) {
+                dlPlayer = cachedPlayer
+            } else {
+                dlPlayer =
+                        if (attrThreads != null) {
+                            DotLottiePlayer.withThreads(config, attrThreads!!)
+                        } else {
+                            DotLottiePlayer(config)
+                        }
+                playerCache[cacheId] = dlPlayer!!
+            }
         } else {
-            DotLottiePlayer(config)
+            dlPlayer =
+                    if (attrThreads != null) {
+                        DotLottiePlayer.withThreads(config, attrThreads!!)
+                    } else {
+                        DotLottiePlayer(config)
+                    }
         }
+
         dlConfig = config
         initialized = true
 
@@ -479,6 +548,8 @@ class DotLottieGLAnimation @JvmOverloads constructor(
         )
         glTargetDirty = false
 
+        if (!(performanceMode == 1 && player.isLoaded())) {
+
         when (content) {
             is DotLottieContent.Json -> {
                 player.loadAnimationData(
@@ -501,6 +572,15 @@ class DotLottieGLAnimation @JvmOverloads constructor(
         if (!smId.isNullOrEmpty()) {
             stateMachineLoad(smId)
             stateMachineStart()
+            }
+        }
+
+        if (cacheId.isNotEmpty() && savedFrames.containsKey(cacheId)) {
+            val savedFrame = savedFrames[cacheId]
+            if (savedFrame != null) {
+                player.setFrame(savedFrame)
+                savedFrames.remove(cacheId)
+            }
         }
 
         // Always render at least one frame so events (e.g. Load) get polled and dispatched
@@ -566,6 +646,14 @@ class DotLottieGLAnimation @JvmOverloads constructor(
     }
 
     // ==================== Public API ====================
+
+    fun setPerformanceMode(mode: Int?) {
+        performanceMode = mode ?: 0
+    }
+
+    fun setCacheId(id: String?) {
+        cacheId = id ?: ""
+    }
 
     fun load(config: ViewConfig) {
         val newDlConfig = Config(
@@ -1016,5 +1104,9 @@ class DotLottieGLAnimation @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "DotLottieGLAnimation"
+        // Global cache of players keyed by cacheId
+        val playerCache = mutableMapOf<String, DotLottiePlayer>()
+        // Saved frames for RAM mode keyed by cacheId
+        val savedFrames = mutableMapOf<String, Float>()
     }
 }


### PR DESCRIPTION

**I had issue with .lottie**
Android's `SurfaceFlinger` has a hardcoded rule to destroy the GL context for out-of-focus screens. The existing Android-lottie implementation struggles to successfully re-hook the rendering context to newly active windows, which leads to `.lottie` hot-reload issues and dropped render hooks. 

To bypass this OS-level limitation and drastically improve remount efficiency, this update introduces a native caching system and exposes two new properties for granular performance tuning.

**Improvements**
* **Persistent Memory Caching (`performanceMode`):** Introduced a global `playerCache` that allows the `DotLottiePlayer` instance to survive view detachment. This entirely eliminates the expensive JSON/binary parsing overhead when remounting the same animation (e.g., when navigating between tabs in a Bottom Navigation Bar).
* **Cache Identification (`cacheId`):** Added support for unique cache identifiers to accurately store and retrieve specific player instances.
* **Lifecycle Stability Guards:** Resolved rare `Window composer not found` crashes. The render-loop is now immediately paused during `onDetachedFromWindow`, and explicit disposal cleanup has been added to the Compose wrapper.
* **Frame State Persistence:** Enhanced RAM mode to automatically save and restore the current frame index across surface recreations, ensuring a visually seamless experience for the end user.

**React Native Integration**
These changes were designed in tandem with updates to the `@lottiefiles/dotlottie-react-native` bridge. By exposing `performanceMode` and `cacheId` through the bridge, React Native applications can now achieve premium UI responsiveness on Android by caching heavy animation models directly in native memory.
